### PR TITLE
Add landing page with image and description

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Pollenomics</title>
+  <style>
+    body {
+      font-family: Georgia, "Times New Roman", Times, serif;
+      margin: 0;
+      padding: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      height: 100vh;
+    }
+    .container {
+      display: flex;
+      align-items: center;
+      max-width: 800px;
+      margin: 20px;
+      gap: 20px;
+    }
+    .text {
+      max-width: 400px;
+      line-height: 1.5;
+    }
+    img {
+      max-width: 300px;
+      height: auto;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="text">
+      <p>Pollenomics is your trusty companion during allergy season. Whether you're using the app directly, glancing at widgets on your home screen or via asking for pollen forecasts via Shortcuts and Siri, Pollenomics has your back.</p>
+    </div>
+    <img src="pollenomics web.png" alt="Pollenomics logo" />
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add simple landing page layout with centered flexbox
- include product description text and image

## Testing
- `npx -y htmlhint index.html` *(fails: 403 Forbidden)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c5607be04883208d33024e183b4c81