### PR TITLE
Add dark mode and responsive layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,8 @@
       align-items: center;
       justify-content: center;
       height: 100vh;
+      background-color: #ffffff;
+      color: #000000;
     }
     .container {
       display: flex;
@@ -27,6 +29,20 @@
     img {
       max-width: 300px;
       height: auto;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      body {
+        background-color: #121212;
+        color: #e0e0e0;
+      }
+    }
+
+    @media (max-width: 600px) {
+      .container {
+        flex-direction: column-reverse;
+        text-align: center;
+      }
     }
   </style>
 </head>


### PR DESCRIPTION
## Summary
- support system dark mode via `prefers-color-scheme`
- stack image above text on narrow/mobile screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5672e7398832099b13c7ba2595d77