### PR TITLE
Add App Store download badge to landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,9 +25,21 @@
     .text {
       max-width: 400px;
       line-height: 1.5;
+      text-align: left;
     }
     img {
       max-width: 300px;
+      height: auto;
+    }
+
+    .app-store-link {
+      display: inline-block;
+      margin-top: 16px;
+    }
+
+    .app-store-link img {
+      max-width: 200px;
+      width: 100%;
       height: auto;
     }
     a, a:visited {
@@ -54,6 +66,9 @@
     <div class="text">
       <p>Pollenomics is your trusty companion during allergy season. Whether you're using the app directly, glancing at widgets on your home screen or via asking for pollen forecasts via Shortcuts and Siri, Pollenomics has your back.</p>
       <p>Have suggestions or need to report a problem? <a href="mailto:coin.sheave-1i@icloud.com">Email me</a>!</p>
+      <a class="app-store-link" href="https://apps.apple.com/se/app/pollenomics/id6747726612" target="_blank" rel="noopener">
+        <img src="Download_on_the_App_Store.png" alt="Download on the App Store" />
+      </a>
     </div>
     <img src="pollenomics web.png" alt="Pollenomics logo" />
   </div>


### PR DESCRIPTION
## Summary
- add a linked App Store badge below the marketing copy
- ensure the badge remains left-aligned and scales appropriately across viewports

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e411e6673c83209a54be75faca5ae0